### PR TITLE
Update server_nginx.html

### DIFF
--- a/server_nginx.html
+++ b/server_nginx.html
@@ -35,13 +35,14 @@ location / {
         return 204;
      }
      if ($request_method = 'POST') {
-        add_header 'Access-Control-Allow-Origin' '*';
+        # For some reason, you want nginx to always return the headers regardless of the response code, you need to add "always" parameter.
+        add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Credentials' 'true';
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
         add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
      }
      if ($request_method = 'GET') {
-        add_header 'Access-Control-Allow-Origin' '*';
+        add_header 'Access-Control-Allow-Origin' '*' always;
         add_header 'Access-Control-Allow-Credentials' 'true';
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
         add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
@@ -49,5 +50,6 @@ location / {
 }
 </pre>
     Source: Michiel Kalkman, <a href="https://michielkalkman.com/snippets/nginx-cors-open-configuration.html">https://michielkalkman.com/snippets/nginx-cors-open-configuration.html</a>
+    According to <a href="http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header">the documentation</a>: <em>add_header</em> only adds the specified field to a response header provided that the response code equals 200, 201, 204, 206, 301, 302, 303, 304, or 307. So if you want the header field will be added regardless of the response code, you need to add <em>always</em> parameter (nginx version >= 1.7.5).
   </section>
 </div>


### PR DESCRIPTION
According to nginx documentation: "add_header" only adds the specified field to a response header provided that the response code equals 200, 201, 204, 206, 301, 302, 303, 304, or 307. So if you want the header field will be added regardless of the response code, you need to add the "always" parameter (nginx version >= 1.7.5).
